### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,7 @@ A lightweight Nuxt 3 component that harnesses the power of CSS animations to cre
 ## Installation
 
 ```sh
-# if you're using npm
-npm i -D nuxt-marquee
-
-# if you're using yarn
-yarn add -D nuxt-marquee
-
-# if you're using pnpm
-pnpm i -D nuxt-marquee
+npx nuxi@latest module add marquee
 ```
 
 ## Usage


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
